### PR TITLE
fix: Update deployment script in CI/CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,7 +45,7 @@ jobs:
           script: |
             cd ${{ secrets.DEPLOY_PATH }} && \
             git fetch --all && \
-            git checkout ${{ github.event.inputs.version }} && \
+            git reset --hard origin/${{ github.event.inputs.version }} && \
             
             # Останавливаем и удаляем контейнеры
             docker compose -f ${{ secrets.DEPLOY_PATH }}/docker-compose.yml --env-file ${{ secrets.DEPLOY_PATH }}/atom/.env.prod down && \


### PR DESCRIPTION
- Changed the git command in the deployment script from 'checkout' to 'reset --hard' to ensure the local branch matches the remote version specified by the input.
- This adjustment improves the reliability of the deployment process by preventing potential issues with local changes interfering with the deployment.